### PR TITLE
Accept request params

### DIFF
--- a/lib/leadlight/request.rb
+++ b/lib/leadlight/request.rb
@@ -55,6 +55,7 @@ module Leadlight
       entity_body = entity.body
       content_type = entity.content_type
       connection.run_request(http_method, url, entity_body, {}) do |request|
+        request.params.update(params) unless params.empty?
         request.headers['Content-Type'] = content_type if content_type
         request.options[:leadlight_request] = self        
         execute_hook(:on_prepare_request, request)


### PR DESCRIPTION
I stole this line from the generated [`Faraday::Connection#get`](https://github.com/technoweenie/faraday/blob/master/lib/faraday/connection.rb#L89). This allows params to be passed through to the request. My specific use case:

``` ruby
root.drops.link('create_file').
  get(name: 'Something Awesome').
  raise_on_error.
  submit_and_wait do |response|
    ...
  end
```
