### PR TITLE
Remove unused method argument

### DIFF
--- a/lib/leadlight/representation.rb
+++ b/lib/leadlight/representation.rb
@@ -21,7 +21,7 @@ module Leadlight
       self
     end
 
-    def exception(message=exception_message)
+    def exception
       return super if defined?(super)
       case __response__.status.to_i
       when 404 then ResourceNotFound


### PR DESCRIPTION
From what I can tell, the `message` argument is never used and [`#exception_message` is overridden](https://github.com/avdi/leadlight/blob/master/spec/leadlight_spec.rb#L155-157) instead.
